### PR TITLE
Fixed a bug that an error occurs when lng is less than 0.0 in Geo3x3_encode () of geo3x3.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,9 +1103,9 @@ $ gawk simple_geo3x3.awk
 [geo3x3.vim](https://github.com/taisukef/Geo3x3/blob/master/geo3x3.vim),
 [simple_geo3x3.vim](https://github.com/taisukef/Geo3x3/blob/master/simple_geo3x3.vim)
 ```Vimscript
-:source geo3x3.vim
-:echo Geo3x3_encode(35.65858, 139.745433, 14)
-:echo Geo3x3_decode("E9139659937288")
+source geo3x3.vim
+echo Geo3x3_encode(35.65858, 139.745433, 14)
+echo Geo3x3_decode("E9139659937288")
 ```
 setup:
 ```bash

--- a/geo3x3.vim
+++ b/geo3x3.vim
@@ -1,51 +1,51 @@
-: fu Geo3x3_encode(lat, lng, level)
-:   let lng = a:lng
-:   if lng >= 0.0
-:     let result = "E"
-:   else
-:     let result = "W"
-:     let lng += 180.0
-:   en
-:   let lat = a:lat + 90.0
-:   let unit = 180.0
-:   for i in range(1, a:level - 1)
-:     let unit /= 3
-:     let x = float2nr(lng / unit)
-:     let y = float2nr(lat / unit)
-:     let n = x + y * 3 + 1
-:     let result = result . n
-:     let lng -= x * unit
-:     let lat -= y * unit
-:   endfor
-:   return result
-: endf
+fu Geo3x3_encode(lat, lng, level)
+  let lng = a:lng
+  if lng >= 0.0
+    let result = "E"
+  else
+    let result = "W"
+    let lng += 180.0
+  en
+  let lat = a:lat + 90.0
+  let unit = 180.0
+  for i in range(1, a:level - 1)
+    let unit /= 3
+    let x = float2nr(lng / unit)
+    let y = float2nr(lat / unit)
+    let n = x + y * 3 + 1
+    let result = result . n
+    let lng -= x * unit
+    let lat -= y * unit
+  endfor
+  return result
+endf
 
-: fu Geo3x3_decode(code)
-:   let code = a:code
-:   let clen = strlen(code)
-:   if clen > 0
-:     let flg = code[0] == "W"
-:     let unit = 180.0
-:     let lat = 0.0
-:     let lng = 0.0
-:     let level = 1
-:     for i in range(1, clen)
-:       let n = float2nr(str2float(code[i]))
-:       if n == 0
-:         break
-:       en
-:       let unit = unit / 3
-:       let n = n - 1
-:       let lng = lng + float2nr(n % 3) * unit
-:       let lat = lat + float2nr(n / 3) * unit
-:       let level = level + 1
-:     endfor
-:     if flg
-:       let lng = lng - 180.0
-:     en
-:     let lat = lat + unit / 2
-:     let lng = lng + unit / 2
-:     let lat = lat - 90
-:     return [lat, lng, level, unit]
-:   en
-: endf
+fu Geo3x3_decode(code)
+  let code = a:code
+  let clen = strlen(code)
+  if clen > 0
+    let flg = code[0] == "W"
+    let unit = 180.0
+    let lat = 0.0
+    let lng = 0.0
+    let level = 1
+    for i in range(1, clen)
+      let n = float2nr(str2float(code[i]))
+      if n == 0
+        break
+      en
+      let unit /= 3
+      let n -= 1
+      let lng += float2nr(n % 3) * unit
+      let lat += float2nr(n / 3) * unit
+      let level += 1
+    endfor
+    if flg
+      let lng -= 180.0
+    en
+    let lat += unit / 2
+    let lng += unit / 2
+    let lat -= 90
+    return [lat, lng, level, unit]
+  en
+endf

--- a/geo3x3.vim
+++ b/geo3x3.vim
@@ -4,7 +4,7 @@
 :     let result = "E"
 :   else
 :     let result = "W"
-:     lng += 180.0
+:     let lng += 180.0
 :   en
 :   let lat = a:lat + 90.0
 :   let unit = 180.0

--- a/simple_geo3x3.vim
+++ b/simple_geo3x3.vim
@@ -1,3 +1,3 @@
-:source geo3x3.vim
-:echo Geo3x3_encode(35.65858, 139.745433, 14)
-:echo Geo3x3_decode("E9139659937288")
+source geo3x3.vim
+echo Geo3x3_encode(35.65858, 139.745433, 14)
+echo Geo3x3_decode("E9139659937288")


### PR DESCRIPTION
Vim scriptでは既にある変数の代入の際にも`let`が必要になります。
今のコードではlngが0.0未満の際の分岐でエラーが発生しますので修正しました。

ご確認お願い致します。

補足:
このプルリクエストには直接関係ありませんが、`:source`で呼び出すVim scriptでは文頭に`:`をつける必要はないです(もちろん付けても全く問題ないため一応お伝えします)。