### PR TITLE
Improve PHP implementation

### DIFF
--- a/Geo3x3.php
+++ b/Geo3x3.php
@@ -1,14 +1,16 @@
 <?php
 
 class Geo3x3 {
-  public static function encode(float $lat, float $lng, int $level): string {
+
+  public static function encode(float $lat, float $lng, int $level): string
+  {
     if ($level < 1) {
-      return "";
+      return '';
     }
     if ($lng >= 0) {
-      $res = "E";
+      $res = 'E';
     } else {
-      $res = "W";
+      $res = 'W';
       $lng += 180;
     }
     $lat += 90;
@@ -23,14 +25,19 @@ class Geo3x3 {
     }
     return $res;
   }
-  public static function decode(string $code): array {
+
+  /**
+   * @phpstan-return array{float, float, positive-int, float}
+   */
+  public static function decode(string $code): array
+  {
     $c = $code[0];
     $begin = 0;
     $flg = false;
-    if ($c == "-" || $c == "W") {
+    if (in_array($c, ['-', 'W'], true)) {
       $flg = true;
       $begin++;
-    } else if ($c == "E" || $c == "+") {
+    } elseif (in_array($c, ['E', '+'], true)) {
       $begin++;
     }
     $unit = 180.0;
@@ -48,7 +55,7 @@ class Geo3x3 {
       $unit /= 3;
       $n--;
       $lng += $n % 3 * $unit;
-      $lat += (int)($n / 3) * $unit;
+      $lat += intdiv($n, 3) * $unit;
       $level++;
     }
     $lat += $unit / 2;
@@ -60,4 +67,3 @@ class Geo3x3 {
     return [$lat, $lng, $level, $unit];
   }
 }
-?>

--- a/README.md
+++ b/README.md
@@ -322,14 +322,14 @@ $ mono ./simple_geo3x3.exe
 [simple_geo3x3.php](https://github.com/taisukef/Geo3x3/blob/master/simple_geo3x3.php)
 ```php
 <?php
-require('Geo3x3.php');
+
+require __DIR__ . '/Geo3x3.php';
 
 $code = Geo3x3::encode(35.65858, 139.745433, 14);
-echo $code . "\n";
+echo "{$code}\n";
 
-$pos = Geo3x3::decode('E9139659937288');
-echo $pos[0] . " " . $pos[1] . " " . $pos[2] . " " . $pos[3] . "\n";
-?>
+[$lat, $lng, $level, $unit] = Geo3x3::decode('E9139659937288');
+echo "{$lat} {$lng} {$level} {$unit}\n";
 ```
 
 to run:

--- a/simple_geo3x3.php
+++ b/simple_geo3x3.php
@@ -1,9 +1,9 @@
 <?php
-require('Geo3x3.php');
+
+require __DIR__ . '/Geo3x3.php';
 
 $code = Geo3x3::encode(35.65858, 139.745433, 14);
-echo $code . "\n";
+echo "{$code}\n";
 
-$pos = Geo3x3::decode('E9139659937288');
-echo $pos[0] . " " . $pos[1] . " " . $pos[2] . " " . $pos[3] . "\n";
-?>
+[$lat, $lng, $level, $unit] = Geo3x3::decode('E9139659937288');
+echo "{$lat} {$lng} {$level} {$unit}\n";


### PR DESCRIPTION
- Use `'` instead of `"` for string literals.
- Use `in_array()` function instead of micro optimization.
- Use `intdiv()` function instead of `(int)` cast.
- Use `elseif` instead of `else if` statement.
- Add PHPStan doc comment for typing.
- Remove unnecessary `?>` closing tags.