### PR TITLE
Improve Emacs Lisp implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,16 +1370,17 @@ $ octave simple_geo3x3.m
 [geo3x3.el](https://github.com/taisukef/Geo3x3/blob/master/geo3x3.el),
 [simple_geo3x3.el](https://github.com/taisukef/Geo3x3/blob/master/simple_geo3x3.el)
 ```Lisp
-(setq load-path nil)
-(load "geo3x3")
+(require 'geo3x3 (expand-file-name "geo3x3" default-directory))
 
-(message (geo3x3_encode 35.65858 139.745433 14))
+(message "encode: %s" (geo3x3-encode 35.65858 139.745433 14))
 
-(setq pos (geo3x3_decode "E9139659937288"))
-(message (number-to-string (nth 0 pos)))
-(message (number-to-string (nth 1 pos)))
-(message (number-to-string (nth 2 pos)))
-(message (number-to-string (nth 3 pos)))
+(pcase (geo3x3-decode "E9139659937288")
+  (`(,lat ,lng ,level ,unit)
+   (message "lat:%f lng:%f level:%d unit:%f" lat lng level unit)))
+
+(pcase (geo3x3-decode "W9")
+  (`(,lat ,lng ,level ,unit)
+   (message "lat:%f lng:%f level:%d unit:%f" lat lng level unit)))
 ```
 setup:
 ```bash

--- a/geo3x3.el
+++ b/geo3x3.el
@@ -1,75 +1,89 @@
-; encode
-(defun encode_fn (code level i lat lng unit)
-    (if (>= i level)
-        code
-        (encode_fn
-            (concat code (int-to-string(+ 1 (floor (/ lng unit)) (* (floor (/ lat unit)) 3))))
-            level
-            (+ i 1)
-            (- lat (* (floor (/ lat unit)) unit))
-            (- lng (* (floor (/ lng unit)) unit))
-            (/ unit 3.0)
-        )
-    )
-)
+;;; geo3x3.el --- A simple geo-coding system for WGS84  -*- lexical-binding: t; -*-
 
-(defun geo3x3_encode (lat lng level)
-    (if (< level 1)
-        ""
-        (encode_fn
-            (if (>= lng 0.0) "E" "W")
-            level
-            1
-            (+ lat 90.0)
-            (if (>= lng 0.0) lng (+ lng 180.0))
-            (/ 180.0 3.0)
-        )
-    )
-)
+;; Copyright (C) 2023  Taisuke Fukuno
 
-; decode
-(defun is_1to9 (c)
-    (string-match c "123456789")
-)
+;; Author: Taisuke Fukuno
+;; Keywords: lisp, convenience
+;; License: CC0-1.0
 
-(defun decode_fn (code lat lng level unit)
-    (if (or (= (length code) 0) (not (is_1to9 (car code))))
-        (list (- (+ lat (/ (* unit 3.0) 2.0)) 90.0) (+ lng (/ (* unit 3.0) 2.0)) level (* unit 3.0))
-        (let (n)
-            (setq n (- (string-to-number (car code)) 1))
-            (decode_fn
-                (cdr code)
-                (+ lat (* (floor (/ n 3)) unit))
-                (+ lng (* (floor (mod n 3)) unit))
-                (+ level 1)
-                (/ unit 3.0)
-            )
-        )
-    )
-)
+;; CC0 1.0 Universal
 
-(defun decode_fne (code)
-    (decode_fn code 0.0 0.0 1 (/ 180.0 3.0))
-)
+;; By marking the work with a CC0 public domain dedication, the creator is giving
+;; up their copyright and allowing reusers to distribute, remix, adapt, and build
+;; upon the material in any medium or format, even for commercial purposes.
 
-(defun decode_fnw (code)
-    (let (pos)
-        (setq pos (decode_fne code))
-        (list (nth 0 pos) (- (nth 1 pos) 180.0) (nth 2 pos) (nth 3 pos))
-    )
-)
+;;; Commentary:
 
-(defun geo3x3_decode (scode)
-    (let (code)
-        (setq code (reverse (cdr (reverse (cdr (split-string scode ""))))))
-        (if (= (length code) 0)
-            (list 0.0 0.0 0 180.0) ; err
-            (progn
-                (if (string= (car code) "W")
-                    (decode_fnw (cdr code))
-                    (decode_fne (cdr code))
-                )
-            )
-        )
-    )
-)
+;; Geo3x3 is a simple geo-coding system for WGS84.
+
+;;; Code:
+
+
+;; encoder
+(defun geo3x3--encode-1 (code level i lat lng unit)
+  "Internal function to encode CODE, LEVEL, I, LAT, LNG and UNIT."
+  (if (>= i level)
+      code
+    (geo3x3--encode-1
+     (concat code (int-to-string(+ 1 (floor (/ lng unit)) (* (floor (/ lat unit)) 3))))
+     level
+     (+ i 1)
+     (- lat (* (floor (/ lat unit)) unit))
+     (- lng (* (floor (/ lng unit)) unit))
+     (/ unit 3.0))))
+
+;;;###autoload
+(defun geo3x3-encode (lat lng level)
+  "Encode Geo3x3 by LAT, LNG and LEVEL."
+  (if (< level 1)
+      ""
+    (geo3x3--encode-1
+     (if (>= lng 0.0) "E" "W")
+     level
+     1
+     (+ lat 90.0)
+     (if (>= lng 0.0) lng (+ lng 180.0))
+     (/ 180.0 3.0))))
+
+;; decoder
+(defsubst geo3x3--is-1to9 (string)
+  "Return non-NIL when STRING matches 1 to 9."
+  (string-match-p (eval-when-compile (rx bos (in "123456789") eos)) string))
+
+(defun geo3x3--decode-1 (code lat lng level unit)
+  "Internal function to decode CODE, LAT, LNG, LEVEL and UNIT."
+  (if (or (= (length code) 0) (not (geo3x3--is-1to9 (car code))))
+      (list (- (+ lat (/ (* unit 3.0) 2.0)) 90.0) (+ lng (/ (* unit 3.0) 2.0)) level (* unit 3.0))
+    (let (n)
+      (setq n (- (string-to-number (car code)) 1))
+      (geo3x3--decode-1
+       (cdr code)
+       (+ lat (* (floor (/ n 3)) unit))
+       (+ lng (* (floor (mod n 3)) unit))
+       (+ level 1)
+       (/ unit 3.0)))))
+
+(defsubst geo3x3--decode-1e (code)
+  "Internal function to decode CODE for eastern hemisphere."
+  (geo3x3--decode-1 code 0.0 0.0 1 (/ 180.0 3.0)))
+
+(defun geo3x3--decode-1w (code)
+  "Internal function to decode CODE for western hemisphere."
+  (let ((pos (geo3x3--decode-1e code)))
+    (list (nth 0 pos)
+          (- (nth 1 pos) 180.0)
+          (nth 2 pos)
+          (nth 3 pos))))
+
+;;;###autoload
+(defun geo3x3-decode (scode)
+  "Decode Geo3x3 by SCODE string."
+  (let ((code (reverse (cdr (reverse (cdr (split-string scode "")))))))
+    (if (= (length code) 0)
+        (list 0.0 0.0 0 180.0)          ; err
+      (if (string= (car code) "W")
+          (geo3x3--decode-1w (cdr code))
+        (geo3x3--decode-1e (cdr code))))))
+
+(provide 'geo3x3)
+;;; geo3x3.el ends here

--- a/simple_geo3x3.el
+++ b/simple_geo3x3.el
@@ -1,16 +1,15 @@
-(setq load-path nil)
-(load "geo3x3")
+;;; Code:
 
-(message (geo3x3_encode 35.65858 139.745433 14))
+(require 'geo3x3 (expand-file-name "geo3x3" default-directory))
 
-(setq pos (geo3x3_decode "E9139659937288"))
-(message (number-to-string (nth 0 pos)))
-(message (number-to-string (nth 1 pos)))
-(message (number-to-string (nth 2 pos)))
-(message (number-to-string (nth 3 pos)))
+(message "encode: %s" (geo3x3-encode 35.65858 139.745433 14))
 
-(setq pos2 (geo3x3_decode "W9"))
-(message (number-to-string (nth 0 pos2)))
-(message (number-to-string (nth 1 pos2)))
-(message (number-to-string (nth 2 pos2)))
-(message (number-to-string (nth 3 pos2)))
+(pcase (geo3x3-decode "E9139659937288")
+  (`(,lat ,lng ,level ,unit)
+   (message "lat:%s lng:%s level:%d unit:%s" lat lng level unit)))
+
+(pcase (geo3x3-decode "W9")
+  (`(,lat ,lng ,level ,unit)
+   (message "lat:%s lng:%s level:%d unit:%s" lat lng level unit)))
+
+;;; simple_geo3x3.el ends here


### PR DESCRIPTION
- Add standard Emacs Lisp header and license notation.
- Rename functions according to [Emacs Lisp code conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html).
- Simplify variable set in `let` form.
- Print messages for each function call at once to make debugging easier from Emacs.

## Before

```
% emacs --script simple_geo3x3.el
Loading /Users/megurine/repo/php/Geo3x3/geo3x3.el (source)...
E9139659937288
35.6586337900162
139.74546563023935
14
0.00011290058538953522
60.0
-30.0
2
60.0
```

## After

```
% emacs --script simple_geo3x3.el
encode: E9139659937288
lat:35.6586337900162 lng:139.74546563023935 level:14 unit:0.00011290058538953522
lat:60.0 lng:-30.0 level:2 unit:60.0
```
